### PR TITLE
📝 Document : 약관 관련 Swagger 작성

### DIFF
--- a/src/main/java/nalance/backend/domain/member/controller/MemberController.java
+++ b/src/main/java/nalance/backend/domain/member/controller/MemberController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import nalance.backend.domain.member.service.EmailCommandService;
 import nalance.backend.domain.member.service.MemberCommandService;
+import nalance.backend.domain.member.service.MemberQueryService;
 import nalance.backend.global.error.ApiResponse;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -20,12 +21,11 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/v0/members")
 @Tag(name = "로그인/회원가입 컨트롤러")
 public class MemberController {
-
-    private MemberCommandService memberCommandService;
-    private EmailCommandService emailCommandService;
+    private final MemberCommandService memberCommandService;
+    private final MemberQueryService memberQueryService;
 
     @PostMapping("/")
-    @Operation(summary = "회원가입 API", description = "회원가입에 사용하는 API입니다.")
+    @Operation(summary = "회원가입 API", description = "회원가입 및 약관 동의를 처리하는 API입니다. 회원 정보와 동의한 약관의 ID 목록이 포함됩니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "MEMBER4002", description = "회원가입에 실패했습니다.")
@@ -53,7 +53,7 @@ public class MemberController {
     @PatchMapping("/email")
     @Operation(
             summary = "이메일 수정 API",
-            description = "로그인된 상태에서 이메일을 수정합니다.",
+            description = "로그인된 상태에서 이메일을 수정하는 api입니다. 변경할 이메일 문자열을 포함합니다.",
             security = @SecurityRequirement(name = "JWT TOKEN")
     )
     @ApiResponses({
@@ -96,4 +96,18 @@ public class MemberController {
         return ApiResponse.onSuccess("회원 탈퇴 성공");
     }
 
+    @GetMapping("/")
+    @Operation(
+            summary = "회원 정보 조회 API",
+            description = "로그인된 회원이 자신의 정보를 조회할 수 있는 API입니다.",
+            security = @SecurityRequirement(name = "JWT TOKEN")
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "MEMBER4001", description = "해당 멤버가 존재하지 않습니다.")
+    })
+    public ApiResponse<MemberProfileResponse> getMemberProfile() {
+        MemberProfileResponse memberProfile = memberQueryService.getMemberProfile();
+        return ApiResponse.onSuccess(memberProfile);
+    }
 }

--- a/src/main/java/nalance/backend/domain/member/dto/MemberDTO.java
+++ b/src/main/java/nalance/backend/domain/member/dto/MemberDTO.java
@@ -1,6 +1,9 @@
 package nalance.backend.domain.member.dto;
 
 import lombok.*;
+import nalance.backend.domain.terms.dto.MemberAgreeDTO;
+
+import java.util.List;
 
 public class MemberDTO {
 
@@ -10,6 +13,7 @@ public class MemberDTO {
             private String email;
             private String password;
             // 닉네임은 고려하지 않았음, 추후 수정 가능
+            private List<MemberAgreeDTO.AgreeTermsRequest> terms; //약관 동의 리스트
         }
 
         @Getter
@@ -49,6 +53,7 @@ public class MemberDTO {
             private String email;
             private String nickname;
             private boolean isActivated;
+            private List<MemberAgreeDTO.AgreeTermsResponse> agreedTerms; // 회원이 동의한 약관 목록
         }
     }
 

--- a/src/main/java/nalance/backend/domain/member/entity/Member.java
+++ b/src/main/java/nalance/backend/domain/member/entity/Member.java
@@ -2,9 +2,13 @@ package nalance.backend.domain.member.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import nalance.backend.domain.terms.entity.MemberAgree;
 import nalance.backend.global.common.BaseEntity;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -29,4 +33,11 @@ public class Member extends BaseEntity {
 
     @Column(nullable = false)
     private Boolean isActivated;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    private List<MemberAgree> memberAgreeList = new ArrayList<>();
+
+    public void encodePassword(String password) {
+        this.password = password;
+    }
 }

--- a/src/main/java/nalance/backend/domain/member/service/MemberQueryService.java
+++ b/src/main/java/nalance/backend/domain/member/service/MemberQueryService.java
@@ -1,0 +1,7 @@
+package nalance.backend.domain.member.service;
+
+import static  nalance.backend.domain.member.dto.MemberDTO.MemberResponse.*;
+
+public interface MemberQueryService {
+    MemberProfileResponse getMemberProfile();
+}

--- a/src/main/java/nalance/backend/domain/member/service/impl/MemberCommandServiceImpl.java
+++ b/src/main/java/nalance/backend/domain/member/service/impl/MemberCommandServiceImpl.java
@@ -13,6 +13,8 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     @Override
     public void joinMember(MemberDTO.MemberRequest.JoinRequest request) {
         // 작성 x
+        // 회원가입 처리
+        // 약관 동의까지 함께 처리
     }
 
     @Override

--- a/src/main/java/nalance/backend/domain/member/service/impl/MemberQueryServiceImpl.java
+++ b/src/main/java/nalance/backend/domain/member/service/impl/MemberQueryServiceImpl.java
@@ -1,0 +1,18 @@
+package nalance.backend.domain.member.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import nalance.backend.domain.member.dto.MemberDTO;
+import nalance.backend.domain.member.service.MemberQueryService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemberQueryServiceImpl implements MemberQueryService {
+    @Override
+    public MemberDTO.MemberResponse.MemberProfileResponse getMemberProfile() {
+        // 작성 x
+        return null;
+    }
+}

--- a/src/main/java/nalance/backend/domain/terms/controller/TermsController.java
+++ b/src/main/java/nalance/backend/domain/terms/controller/TermsController.java
@@ -1,0 +1,47 @@
+package nalance.backend.domain.terms.controller;
+
+import static nalance.backend.domain.terms.dto.TermsDTO.TermsResponse.*;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import nalance.backend.domain.member.dto.MemberDTO;
+import nalance.backend.domain.terms.dto.TermsDTO;
+import nalance.backend.domain.terms.service.TermsQueryService;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import nalance.backend.global.error.ApiResponse;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@Validated
+@RequestMapping("/api/v0/terms")
+@Tag(name = "약관 컨트롤러")
+public class TermsController {
+    private final TermsQueryService termsQueryService;
+
+    @GetMapping("/")
+    @Operation(summary = "전체 약관 조회 API", description = "전체 약관 목록을 조회하는 API입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "TERMS4001", description = "전체 약관 목록 조회에 실패했습니다.")
+    })
+    public ApiResponse<List<TermsDetailResponse>> getAllTerms() {
+        List<TermsDetailResponse> termsList = termsQueryService.getAllTerms();
+        return ApiResponse.onSuccess(termsList);
+    }
+
+    @GetMapping("/{termsId}")
+    @Operation(summary = "약관 개별 조회 API", description = "특정 약관의 세부 정보를 조회하는 API입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "TERMS4002", description = "약관 개별 조회에 실패했습니다.")
+    })
+    public ApiResponse<TermsDetailResponse> getTermsById(@PathVariable Long termsId) {
+        TermsDetailResponse terms = termsQueryService.getTermsById(termsId);
+        return ApiResponse.onSuccess(terms);
+    }
+}

--- a/src/main/java/nalance/backend/domain/terms/dto/MemberAgreeDTO.java
+++ b/src/main/java/nalance/backend/domain/terms/dto/MemberAgreeDTO.java
@@ -1,0 +1,21 @@
+package nalance.backend.domain.terms.dto;
+
+import lombok.*;
+import nalance.backend.global.common.enums.Type;
+
+public class MemberAgreeDTO {
+    @Getter
+    public static class AgreeTermsRequest {
+        private Long termsId;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class AgreeTermsResponse {
+        private Long termsId;
+        private String content;
+        private Type type;
+    }
+}

--- a/src/main/java/nalance/backend/domain/terms/dto/TermsDTO.java
+++ b/src/main/java/nalance/backend/domain/terms/dto/TermsDTO.java
@@ -4,25 +4,15 @@ import lombok.*;
 import nalance.backend.global.common.enums.Type;
 
 public class TermsDTO {
-    @Getter
-    public static class TermsCreateRequest {
-        private String content;
-        private Type type;
-    }
-
-    @Getter
-    public static class AgreeTermsRequest {
-        private boolean isAgreed;
-    }
-
-    @Builder
-    @Getter
-    @NoArgsConstructor(access = AccessLevel.PROTECTED)
-    @AllArgsConstructor(access = AccessLevel.PROTECTED)
     public static class TermsResponse {
-        private Long termsId;
-        private String content;
-        private Type type;
-        private boolean isAgreed;
+        @Builder
+        @Getter
+        @NoArgsConstructor(access = AccessLevel.PROTECTED)
+        @AllArgsConstructor(access = AccessLevel.PROTECTED)
+        public static class TermsDetailResponse {
+            private Long termsId;
+            private String content;
+            private Type type;
+        }
     }
 }

--- a/src/main/java/nalance/backend/domain/terms/entity/MemberAgree.java
+++ b/src/main/java/nalance/backend/domain/terms/entity/MemberAgree.java
@@ -27,7 +27,4 @@ public class MemberAgree {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "terms_id", nullable = false)
     private Terms terms;
-
-    @Column(nullable = false)
-    private Boolean isAgreed;
 }

--- a/src/main/java/nalance/backend/domain/terms/entity/Terms.java
+++ b/src/main/java/nalance/backend/domain/terms/entity/Terms.java
@@ -7,6 +7,9 @@ import nalance.backend.global.common.enums.Type;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @DynamicInsert
@@ -24,4 +27,7 @@ public class Terms extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     private Type type;
+
+    @OneToMany(mappedBy = "terms", cascade = CascadeType.ALL)
+    private List<MemberAgree> memberAgreeList = new ArrayList<>();
 }

--- a/src/main/java/nalance/backend/domain/terms/service/TermsQueryService.java
+++ b/src/main/java/nalance/backend/domain/terms/service/TermsQueryService.java
@@ -1,0 +1,10 @@
+package nalance.backend.domain.terms.service;
+
+import static nalance.backend.domain.terms.dto.TermsDTO.TermsResponse.*;
+
+import java.util.List;
+
+public interface TermsQueryService {
+    List<TermsDetailResponse> getAllTerms();
+    TermsDetailResponse getTermsById(Long termsId);
+}

--- a/src/main/java/nalance/backend/domain/terms/service/impl/TermsQueryServiceImpl.java
+++ b/src/main/java/nalance/backend/domain/terms/service/impl/TermsQueryServiceImpl.java
@@ -1,0 +1,28 @@
+package nalance.backend.domain.terms.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import nalance.backend.domain.terms.dto.TermsDTO;
+import nalance.backend.domain.terms.service.TermsQueryService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class TermsQueryServiceImpl implements TermsQueryService {
+    @Override
+    public List<TermsDTO.TermsResponse.TermsDetailResponse> getAllTerms() {
+        // 작성 x
+        // 약관 리스트 형태로 전체 출력
+        return null;
+    }
+
+    @Override
+    public TermsDTO.TermsResponse.TermsDetailResponse getTermsById(Long termsId) {
+        // 작성 x
+        // 약관 하나만 출력
+        return null;
+    }
+}

--- a/src/main/java/nalance/backend/global/error/code/status/ErrorStatus.java
+++ b/src/main/java/nalance/backend/global/error/code/status/ErrorStatus.java
@@ -28,8 +28,12 @@ public enum ErrorStatus implements BaseErrorCode {
     FAIL_UPDATE_ID(HttpStatus.BAD_REQUEST, "MEMBER4004", "아이디 변경에 실패했습니다."),
     INCORRECT_PASSWORD_CODE(HttpStatus.BAD_REQUEST, "MEMBER4005", "비밀 번호 확인이 일치하지 않습니다."),
     FAIL_UPDATE_PASSWORD(HttpStatus.BAD_REQUEST, "MEMBER4006", "비밀번호 변경에 실패했습니다."),
-    FAIL_DELETE_MEMBER(HttpStatus.BAD_REQUEST, "MEMBER4007", "회원 탈퇴에 실패했습니다.");
+    FAIL_DELETE_MEMBER(HttpStatus.BAD_REQUEST, "MEMBER4007", "회원 탈퇴에 실패했습니다."),
 
+    // Terms 관련 에러
+    FAIL_GET_TERMS(HttpStatus.BAD_REQUEST, "TERMS4001", "약관 목록 조회에 실패했습니다."),
+    FAIl_GET_TERMS_DETAIL(HttpStatus.BAD_REQUEST, "TERMS4002", "개별 약관 조회에 실패했습니다."),
+    NOT_FOUND_TERMS(HttpStatus.NOT_FOUND, "TERMS4003", "해당 약관이 존재하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
# 💡 PR Summary - 약관 관련 api Swagger 작성
<!-- 어떤 작업에 대한 PR 인지 위 주석에 적어주세요 -->

### 📝 Description

---

- MemberAgree 엔터티의 isAgreed 속성을 삭제하고, MemberAgree 테이블의 존재 여부가 약관 동의 여부로 결정되도록 수정 (원래 erd 설계했던대로 돌아감..)
- 회원 가입 API에서 회원 가입 진행 중에 사용자가 '동의함'으로 선택한 약관의 ID를 함께 Request Body로 보내면서 회원 가입이 진행되도록 수정
- 로그인된 멤버가 자신의 정보를 조회할 수 있는 회원 정보 조회 API Swagger 추가
- 약관 목록 조회와 세부 약관 조회 API Swagger 작성

### 🌲 Working Branch

---
<!-- 예시) feature/user -->

- feature/#31

### 📖 Related Issues

---
<!-- 예시) #1 -->

- #31 

### 📚 Etc

---
<!-- 작업 중 특이사항이 생기면 적어주세요 -->
특이사항