### PR TITLE
✨ Feature : 업로드된 파일(jpg, png) 이메일로 전송 기능 구현

### DIFF
--- a/src/main/java/nalance/backend/domain/member/dto/EmailDTO.java
+++ b/src/main/java/nalance/backend/domain/member/dto/EmailDTO.java
@@ -24,12 +24,6 @@ public class EmailDTO {
             @CheckEmailCode
             private String code;
         }
-
-        @Getter
-        public static class EmailImageSendRequest {
-            // TODO validation
-            private String imageUrl;
-        }
     }
 
 }

--- a/src/main/java/nalance/backend/domain/member/service/EmailCommandService.java
+++ b/src/main/java/nalance/backend/domain/member/service/EmailCommandService.java
@@ -1,6 +1,7 @@
 package nalance.backend.domain.member.service;
 
 import nalance.backend.domain.member.dto.EmailDTO.EmailRequest.*;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface EmailCommandService {
 
@@ -8,5 +9,5 @@ public interface EmailCommandService {
 
     void verificationEmailCode(VerificationEmailCodeRequest request);
 
-    void sendImageToEmail(EmailImageSendRequest request);
+    void sendImageToEmail(MultipartFile file, String email);
 }

--- a/src/main/java/nalance/backend/domain/member/service/impl/EmailCommandServiceImpl.java
+++ b/src/main/java/nalance/backend/domain/member/service/impl/EmailCommandServiceImpl.java
@@ -1,7 +1,6 @@
 package nalance.backend.domain.member.service.impl;
 
 import lombok.RequiredArgsConstructor;
-import nalance.backend.domain.member.dto.EmailDTO.EmailRequest.EmailImageSendRequest;
 import nalance.backend.domain.member.dto.EmailDTO.EmailRequest.EmailSendVerificationRequest;
 import nalance.backend.domain.member.dto.EmailDTO.EmailRequest.VerificationEmailCodeRequest;
 import nalance.backend.domain.member.service.EmailCommandService;
@@ -11,6 +10,7 @@ import nalance.backend.global.error.handler.EmailException;
 import nalance.backend.global.redis.RedisUtil;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @Transactional
@@ -23,7 +23,7 @@ public class EmailCommandServiceImpl implements EmailCommandService {
     @Override
     public void sendVerificationCodeToEmail(EmailSendVerificationRequest request) {
         try {
-            emailUtil.sendMessage(request.getEmail());
+            emailUtil.sendCodeMessage(request.getEmail());
         } catch (Exception e) {
             throw new EmailException(ErrorStatus.FAIL_SEND_EMAIL);
         }
@@ -46,7 +46,11 @@ public class EmailCommandServiceImpl implements EmailCommandService {
     }
 
     @Override
-    public void sendImageToEmail(EmailImageSendRequest request) {
-        // TODO 로직
+    public void sendImageToEmail(MultipartFile file, String email) {
+        try {
+            emailUtil.sendImageMessage(email, file);
+        } catch (Exception e) {
+            throw new EmailException(ErrorStatus.FAIL_SEND_EMAIL);
+        }
     }
 }

--- a/src/main/java/nalance/backend/global/error/code/status/ErrorStatus.java
+++ b/src/main/java/nalance/backend/global/error/code/status/ErrorStatus.java
@@ -29,6 +29,13 @@ public enum ErrorStatus implements BaseErrorCode {
     INCORRECT_EMAIL_CODE(HttpStatus.BAD_REQUEST, "EMAIL4003", "인증번호가 일치하지 않습니다."),
     INVALID_EMAIL_CODE(HttpStatus.BAD_REQUEST, "EMAIL4004", "인증번호 형식이 올바르지 않습니다."),
 
+    // 파일 관련 에러
+    INVALID_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "FILE4001", "파일 형식이 올바르지 않습니다."),
+    NOT_UPLOAD_FILE(HttpStatus.BAD_REQUEST, "FILE4002", "파일이 업로드되지 않았습니다."),
+    TOO_BIG_SIZE_FILE(HttpStatus.BAD_REQUEST, "FILE4003", "파일 크기는 5MB를 초과할 수 없습니다."),
+    INVALID_MIME_TYPE(HttpStatus.BAD_REQUEST, "FILE4004", "허용되지 않는 MIME 형식입니다. (허용 형식: image/jpeg, image/png)"),
+    INVALID_FILE_NAME(HttpStatus.BAD_REQUEST, "FILE4005", "잘못된 파일 이름입니다."),
+
     // Member 관련 에러
     MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4001", "해당 멤버가 존재하지 않습니다."),
     FAIL_JOIN_MEMBER(HttpStatus.BAD_REQUEST, "MEMBER4002", "회원 가입에 실패했습니다."),

--- a/src/main/java/nalance/backend/global/security/SecurityConfig.java
+++ b/src/main/java/nalance/backend/global/security/SecurityConfig.java
@@ -29,6 +29,7 @@ public class SecurityConfig implements WebMvcConfigurer {
                                 new AntPathRequestMatcher("/"),
                                 new AntPathRequestMatcher("/api/v0/emails/verification"),
                                 new AntPathRequestMatcher("/api/v0/emails/send-verification"),
+                                new AntPathRequestMatcher("/api/v0/emails/picture/send-screenshot"),
                                 new AntPathRequestMatcher("/api/v0/members"),
                                 new AntPathRequestMatcher("/api/v0/categories/**"),
                                 new AntPathRequestMatcher("/api/v0/members/{memberId}/categories"),

--- a/src/main/java/nalance/backend/global/validation/annotation/CheckFile.java
+++ b/src/main/java/nalance/backend/global/validation/annotation/CheckFile.java
@@ -1,0 +1,21 @@
+package nalance.backend.global.validation.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import nalance.backend.global.validation.validator.CheckFileValidator;
+
+@Documented
+@Constraint(validatedBy = CheckFileValidator.class)
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CheckFile {
+
+    String message() default "파일 형식이 올바르지 않습니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/nalance/backend/global/validation/validator/CheckFileValidator.java
+++ b/src/main/java/nalance/backend/global/validation/validator/CheckFileValidator.java
@@ -1,0 +1,84 @@
+package nalance.backend.global.validation.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import nalance.backend.global.error.code.status.ErrorStatus;
+import nalance.backend.global.validation.annotation.CheckFile;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+@Component
+public class CheckFileValidator implements ConstraintValidator<CheckFile, MultipartFile> {
+
+    @Override
+    public void initialize(CheckFile constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(MultipartFile value, ConstraintValidatorContext context) {
+        if (value == null || value.isEmpty()) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus.NOT_UPLOAD_FILE.toString())
+                    .addConstraintViolation();
+            return false;
+        }
+
+        long maxSize = 5 * 1024 * 1024; // 5MB
+        if (value.getSize() > maxSize) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus.TOO_BIG_SIZE_FILE.toString())
+                    .addConstraintViolation();
+            return false;
+        }
+
+        String extension = getFileExtension(value.getOriginalFilename());
+        if (!isValidExtension(extension)) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus.INVALID_FILE_EXTENSION.toString())
+                    .addConstraintViolation();
+            return false;
+        }
+
+        String mimeType = value.getContentType();
+        if (!isValidMimeType(mimeType)) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus.INVALID_MIME_TYPE.toString())
+                    .addConstraintViolation();
+            return false;
+        }
+
+        String fileName = value.getOriginalFilename();
+        if (fileName.contains("..")) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus.INVALID_FILE_NAME.toString())
+                    .addConstraintViolation();
+            return false;
+        }
+        return true;
+    }
+
+    // 파일 확장자 유효성 확인
+    private boolean isValidExtension(String extension) {
+        String[] allowedExtensions = {"jpg", "jpeg", "png"};
+        for (String allowedExtension : allowedExtensions) {
+            if (allowedExtension.equalsIgnoreCase(extension)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // MIME 타입 유효성 확인
+    private boolean isValidMimeType(String mimeType) {
+        return mimeType != null && (mimeType.equalsIgnoreCase("image/jpeg") || mimeType.equalsIgnoreCase("image/png"));
+    }
+
+    // 파일 확장자 추출
+    private String getFileExtension(String fileName) {
+        if (fileName == null || !fileName.contains(".")) {
+            return "";
+        }
+        return fileName.substring(fileName.lastIndexOf(".") + 1);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,10 @@ spring:
   sql:
     init:
       mode: never
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
 
   jpa:
     properties:


### PR DESCRIPTION
# 💡 PR Summary - 업로드된 파일(jpg, png) 이메일로 전송 기능 구현
<!-- 어떤 작업에 대한 PR 인지 위 주석에 적어주세요 -->

### 📝 Description

---
<!-- 어떤 작업을 했는지 간단하게 적어주세요 -->
- 업로드된 파일(jpg, png) 이메일로 전송 기능 구현
- 파일 validation

### 🌲 Working Branch

---
<!-- 예시) feature/user -->
- feature/#44

### 📖 Related Issues

---
<!-- 예시) #1 -->
- #44


### 📚 Etc

---
<!-- 작업 중 특이사항이 생기면 적어주세요 -->
- swagger에서 파일을 올리기 위해 `@PostMapping(value = "/picture/send-screenshot", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)` 에서 consumes = 부분을 추가
- 로그인이 완료되면 파라미터로 받는 email을 없애고 token을 받을 예정