### PR TITLE
🐛 Fix : 카테고리 여러개 생성 시 색상 valid 응답 500대 오류 발생 및 중복값 요청 예외 처리

### DIFF
--- a/src/main/java/nalance/backend/domain/category/controller/CategoryController.java
+++ b/src/main/java/nalance/backend/domain/category/controller/CategoryController.java
@@ -60,7 +60,8 @@ public class CategoryController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CATEGORY4004", description = "카테고리 색상은 필수 입니다."),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CATEGORY4005", description = "해당 카테고리명은 이미 존재합니다."),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CATEGORY4006", description = "해당 색상은 이미 존재합니다."),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CATEGORY4007", description = "유효하지 않은 색상입니다.")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CATEGORY4007", description = "유효하지 않은 색상입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CATEGORY4008", description = "중복된 요청 값이 존재합니다.")
     })
     public ApiResponse<?> createManyCategory(@RequestBody @Valid List<CategoryDTO.CategoryRequest> categoryRequest){
         categoryCommandService.createManyCateory(categoryRequest);

--- a/src/main/java/nalance/backend/domain/category/service/impl/CategoryCommandServiceImpl.java
+++ b/src/main/java/nalance/backend/domain/category/service/impl/CategoryCommandServiceImpl.java
@@ -47,22 +47,27 @@ public class CategoryCommandServiceImpl implements CategoryCommandService {
     public void createManyCateory(List<CategoryDTO.CategoryRequest> categoryRequests) {
         // 현재 로그인된 회원의 ID 가져오기
         Long memberId = SecurityUtil.getCurrentMemberId();
-        // Valid : 멤버의 기존 카테고리 이름 중복여부 확인
-        List<String> newCategoryNames = categoryRequests.stream()
-                .map(CategoryDTO.CategoryRequest::getCategoryName)
-                .toList();
-
-        if (!categoryRequests.isEmpty()) {
-            validateCategoryNames(newCategoryNames);
+        // 각 카테고리에 대한 유효성 검증
+        for (CategoryDTO.CategoryRequest request : categoryRequests) {
+            validateCategoryNames(List.of(request.getCategoryName())); // 이름 검증
+            validateCategoryColors(List.of(request.getColor()));       // 색상 검증
         }
-        // Valid : 멤버의 기존 카테고리 색상 중복여부 확인
-        List<String> newCategoryColors = categoryRequests.stream()
-                .map(CategoryDTO.CategoryRequest::getColor)
-                .toList();
-
-        if (!categoryRequests.isEmpty()) {
-            validateCategoryColors(newCategoryColors);
-        }
+//        // Valid : 멤버의 기존 카테고리 이름 중복여부 확인
+//        List<String> newCategoryNames = categoryRequests.stream()
+//                .map(CategoryDTO.CategoryRequest::getCategoryName)
+//                .toList();
+//
+//        if (!categoryRequests.isEmpty()) {
+//            validateCategoryNames(newCategoryNames);
+//        }
+//        // Valid : 멤버의 기존 카테고리 색상 중복여부 확인
+//        List<String> newCategoryColors = categoryRequests.stream()
+//                .map(CategoryDTO.CategoryRequest::getColor)
+//                .toList();
+//
+//        if (!categoryRequests.isEmpty()) {
+//            validateCategoryColors(newCategoryColors);
+//        }
         // 카테고리 리스트 생성 및 변환
         List<Category> categories = categoryRequests.stream().map(
                 categoryRequest ->  Category.builder()

--- a/src/main/java/nalance/backend/global/controller/BasicController.java
+++ b/src/main/java/nalance/backend/global/controller/BasicController.java
@@ -1,0 +1,21 @@
+package nalance.backend.global.controller;
+
+import nalance.backend.global.validation.validator.CollectionValidator;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+import org.springframework.web.bind.WebDataBinder;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.InitBinder;
+
+@ControllerAdvice
+public class BasicController {
+    protected final LocalValidatorFactoryBean validator;
+
+    public BasicController(LocalValidatorFactoryBean validator) {
+        this.validator = validator;
+    }
+
+    @InitBinder
+    public void initBinder(WebDataBinder binder) {
+        binder.addValidators(new CollectionValidator(validator));
+    }
+}

--- a/src/main/java/nalance/backend/global/error/code/status/ErrorStatus.java
+++ b/src/main/java/nalance/backend/global/error/code/status/ErrorStatus.java
@@ -22,6 +22,8 @@ public enum ErrorStatus implements BaseErrorCode {
     CATEGORY_NAME_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "CATEGORY4005", "해당 카테고리명은 이미 존재합니다."),
     CATEGORY_COLOR_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "CATEGORY4006", "해당 색상은 이미 존재합니다."),
     CATEGORY_COLOR_UNUSABLE(HttpStatus.BAD_REQUEST, "CATEGORY4007", "유효하지 않은 색상입니다."),
+    CATEGORY_DUPLICATE_REQUESTS(HttpStatus.BAD_REQUEST, "CATEGORY4008", "중복 된 요청값입니다."),
+
 
     // 페이지 number 없음 에러
     INVALID_PAGE_NUMBER(HttpStatus.BAD_REQUEST,"PAGE4001","올바르지 않은 페이징 번호입니다."),

--- a/src/main/java/nalance/backend/global/validation/validator/CollectionValidator.java
+++ b/src/main/java/nalance/backend/global/validation/validator/CollectionValidator.java
@@ -1,0 +1,32 @@
+package nalance.backend.global.validation.validator;
+
+import org.springframework.validation.Errors;
+import org.springframework.validation.ValidationUtils;
+import org.springframework.validation.Validator;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+import java.util.Collection;
+import java.util.List;
+
+public class CollectionValidator implements Validator {
+    private final Validator validator;
+
+    public CollectionValidator(LocalValidatorFactoryBean validatorFactory) {
+        this.validator = validatorFactory;
+    }
+
+    @Override
+    public boolean supports(Class<?> clazz) {
+        return true;
+    }
+
+    @Override
+    public void validate(Object target, Errors errors) {
+        if (target instanceof List) {
+            Collection collection = (Collection) target;
+            for (Object object : collection) {
+                ValidationUtils.invokeValidator(validator, object, errors);
+            }
+        }
+    }
+}


### PR DESCRIPTION
# 💡 PR Summary - 카테고리 여러개 생성 시 색상 valid 응답 500대 오류 발생 및 중복값 요청 예외 처리
<!-- 어떤 작업에 대한 PR 인지 위 주석에 적어주세요 -->

### 📝 Description

---
<!-- 어떤 작업을 했는지 간단하게 적어주세요 -->
- 카테고리 여러개 생성 시, 유효하지 않은 색상 값 400대로 예외 처리
- ReqeustBody로 List전달 시, Valid체크 가능하도록 AOP와 CustomValidator를 사용
- 중복 된 카테고리들 생성 요청 시 예외 처리

### 🌲 Working Branch

---
<!-- 예시) feature/user -->
- bug/#75

### 📖 Related Issues

---
<!-- 예시) #1 -->
- #75


### 📚 Etc

---
<!-- 작업 중 특이사항이 생기면 적어주세요 -->