### PR TITLE
🐛 Fix : Todo 조회 API에서  RequestBody 대신 RequestParam 적용

### DIFF
--- a/src/main/java/nalance/backend/domain/todo/controller/TodoController.java
+++ b/src/main/java/nalance/backend/domain/todo/controller/TodoController.java
@@ -19,8 +19,12 @@ import nalance.backend.global.validation.annotation.CheckPage;
 import nalance.backend.global.validation.annotation.ExistTodo;
 import nalance.backend.global.validation.validator.CheckPageValidator;
 import org.springframework.data.domain.Page;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -106,10 +110,12 @@ public class TodoController {
     @Parameters({
             @Parameter(name = "page", description = "페이지 번호, 1번이 1 페이지 입니다.")
     })
-    public ApiResponse<TodoPreviewListResponse> getTodoList(@RequestBody @Valid TodoQueryRequest todoQueryRequest,
+    public ApiResponse<TodoPreviewListResponse> getTodoList(@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) List<LocalDate> dateList,
+                                                            @RequestParam(required = false) List<Long> categoryIdList,
+                                                            @RequestParam(required = false) Integer status,
                                                             @CheckPage@RequestParam(name = "page") Integer page) {
         Integer validatedPage = checkPageValidator.validateAndTransformPage(page);
-        Page<Todo> todoList = todoQueryService.getTodoList(todoQueryRequest, validatedPage);
+        Page<Todo> todoList = todoQueryService.getTodoList(dateList, categoryIdList, status, validatedPage);
         return ApiResponse.onSuccess(TodoConverter.toTodoPreviewListResponse(todoList));
     }
 

--- a/src/main/java/nalance/backend/domain/todo/dto/TodoDTO.java
+++ b/src/main/java/nalance/backend/domain/todo/dto/TodoDTO.java
@@ -43,13 +43,6 @@ public class TodoDTO {
             private LocalDate date;
         }
 
-        @Getter
-        public static class TodoQueryRequest {
-            private List<LocalDate> dateList;
-            private List<Long> categoryIdList;
-            private Integer status;
-        }
-
     }
 
     public static class TodoResponse{

--- a/src/main/java/nalance/backend/domain/todo/service/TodoQueryService.java
+++ b/src/main/java/nalance/backend/domain/todo/service/TodoQueryService.java
@@ -4,10 +4,12 @@ import nalance.backend.domain.todo.dto.TodoDTO;
 import nalance.backend.domain.todo.entity.Todo;
 import org.springframework.data.domain.Page;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 public interface TodoQueryService {
     Optional<Todo> findTodo(Long id);
 
-    Page<Todo> getTodoList(TodoDTO.TodoRequest.TodoQueryRequest todoQueryRequest, Integer page);
+    Page<Todo> getTodoList(List<LocalDate> dateList, List<Long> categoryIdList, Integer status, Integer page);
 }

--- a/src/main/java/nalance/backend/domain/todo/service/impl/TodoQueryServiceImpl.java
+++ b/src/main/java/nalance/backend/domain/todo/service/impl/TodoQueryServiceImpl.java
@@ -18,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import static  nalance.backend.domain.todo.dto.TodoDTO.TodoResponse.*;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -35,7 +36,7 @@ public class TodoQueryServiceImpl implements TodoQueryService {
     }
 
     @Override
-    public Page<Todo> getTodoList(TodoDTO.TodoRequest.TodoQueryRequest todoQueryRequest, Integer page) {
+    public Page<Todo> getTodoList(List<LocalDate> dateList, List<Long> categoryIdList, Integer status, Integer page) {
 
         Long memberId = SecurityUtil.getCurrentMemberId();
         Member member = memberRepository.findById(memberId)
@@ -43,9 +44,9 @@ public class TodoQueryServiceImpl implements TodoQueryService {
 
         return todoRepository.findTodos(
                 member,
-                todoQueryRequest.getDateList(),
-                todoQueryRequest.getCategoryIdList(),
-                todoQueryRequest.getStatus(),
+                dateList,
+                categoryIdList,
+                status,
                 PageRequest.of(page, 10));
     }
 }


### PR DESCRIPTION
# 💡 PR Summary - Todo 조회 API에서  RequestBody 대신 RequestParam 적용
<!-- 어떤 작업에 대한 PR 인지 위 주석에 적어주세요 -->

### 📝 Description

---
<!-- 어떤 작업을 했는지 간단하게 적어주세요 -->
Get 요청에 request body를 넣으니 무한 로딩 오류가 남.
request body 를 request param 으로 변경

### 🌲 Working Branch

---
<!-- 예시) feature/user -->
- bug/#99

### 📖 Related Issues

---
<!-- 예시) #1 -->
- #99 


### 📚 Etc

---
<!-- 작업 중 특이사항이 생기면 적어주세요 -->
특이사항